### PR TITLE
add  python3-dev dependancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Currently, this will maintain a static number of UTXOs. This is important becaus
 
 ## Dependencies
 ```shell
+sudo apt-get install python3-dev
 sudo apt-get install python3 libgnutls28-dev libssl-dev
 sudo apt-get install python3-pip
 pip3 install base58 slick-bitcoinrpc


### PR DESCRIPTION
had issues installing slick-bitcoinrpc, solved by installing python3-dev first.